### PR TITLE
Fixes four issues that prevent RHEL9 based EKS nodes from joining an EKS cluster

### DIFF
--- a/templates/rhel/provisioners/cache-pause-container.sh
+++ b/templates/rhel/provisioners/cache-pause-container.sh
@@ -7,5 +7,5 @@ set -o pipefail
 export AWS_DEFAULT_REGION=$AWS_REGION
 export AWS_CA_BUNDLE="/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
 sudo systemctl start containerd
-cache-pause-container -i ${PAUSE_CONTAINER_IMAGE}
+sudo cache-pause-container -i ${PAUSE_CONTAINER_IMAGE}
 sudo systemctl stop containerd

--- a/templates/rhel/provisioners/configure-selinux.sh
+++ b/templates/rhel/provisioners/configure-selinux.sh
@@ -4,10 +4,17 @@ set -o pipefail
 set -o nounset
 
 validate_directory_selinux_contexts() {
-  local DIR=$1
+  local DIR="$1"
   echo "Validating SELinux contexts in $DIR"
 
-  unverified_files=$(matchpathcon -V $DIR/* | grep -v verified)
+  # Skip if directory does not exist
+  if [ ! -d "$DIR" ]; then
+    echo "Directory $DIR does not exist, skipping validation"
+    return 0
+  fi
+
+  unverified_files=$(sudo find "$DIR" -mindepth 1 -maxdepth 1 \
+    -exec matchpathcon -V {} + 2>/dev/null | grep -v verified)
 
   if [ -n "$unverified_files" ]; then
     echo "$unverified_files"

--- a/templates/rhel/provisioners/fix-nodeadm-cloudinit-ordering.sh
+++ b/templates/rhel/provisioners/fix-nodeadm-cloudinit-ordering.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# File: fix-nodeadm-cloudinit-ordering.sh
+#
+# Fixes three issues that prevent EKS nodes from joining the cluster on RHEL9
+# when cloud-init version 24.4+ is present.
+#
+# Issue 1 — systemd ordering cycle via WantedBy=multi-user.target:
+#   cloud-init 24.4 changed systemd ordering so that cloud-final runs
+#   AFTER multi-user.target. Both nodeadm-run.service and
+#   nodeadm-boot-hook.service declare:
+#     After=cloud-final.service
+#     WantedBy=multi-user.target
+#   This creates a cycle:
+#     multi-user.target → nodeadm-* → cloud-final → multi-user.target
+#   systemd breaks the cycle by deleting the nodeadm start jobs,
+#   meaning kubelet never starts and the node never joins the EKS cluster.
+#
+#   Fix: Change WantedBy=multi-user.target to WantedBy=cloud-init.target
+#   so nodeadm services are ordered under cloud-init.target instead.
+#
+# Issue 2 — residual ordering cycle via After=cloud-final.service:
+#   Even after fixing WantedBy, the After=cloud-final.service directive
+#   creates a second cycle:
+#     cloud-init.target → nodeadm-run → After=cloud-final
+#     cloud-final → must complete before cloud-init.target
+#   systemd still detects this as a cycle and deletes the nodeadm-run
+#   start job. The After=cloud-final.service must be removed entirely.
+#   nodeadm-run only needs to run after nodeadm-config.service, which
+#   is the legitimate sequential dependency and is safe to keep.
+#
+#   Fix: Remove cloud-final.service from the After= directive, leaving
+#   only After=nodeadm-config.service.
+#
+# Issue 3 — missing /usr/bin/networkctl (systemd-networkd not installed):
+#   nodeadm-internal writes systemd-networkd config files to
+#   /run/systemd/network/ and then calls "networkctl reload" via the
+#   udev-net-manager@eth0.service ExecStartPost directive.
+#   On RHEL9 with NetworkManager, systemd-networkd is not installed by
+#   default, so networkctl is missing and the service fails and retries
+#   continuously until it hits the restart limit.
+#
+#   Fix: Create a /usr/bin/networkctl shim that translates the reload
+#   call to the NetworkManager equivalent (nmcli general reload).
+#
+# Issue 4 — nm-cloud-setup re-enabled by NetworkManager-cloud-setup RPM:
+#   The NetworkManager-cloud-setup package post-install scriptlet
+#   re-enables nm-cloud-setup.timer and nm-cloud-setup.service whenever
+#   the package is installed or upgraded. This causes network routing
+#   disruption on EKS nodes. Masking (symlink to /dev/null) prevents
+#   any package operation from re-enabling them.
+#
+#   Fix: Mask both nm-cloud-setup units so they cannot be re-enabled
+#   by any subsequent package install or upgrade.
+#
+# References:
+#   https://github.com/aws-samples/amazon-eks-ami-rhel/pull/20
+#   https://cloudinit.readthedocs.io/en/latest/reference/breaking_changes.html#id4
+
+set -euo pipefail
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+log "=== fix-nodeadm-cloudinit-ordering: start ==="
+
+# ---------------------------------------------------------------------------
+# Issues 1 & 2: Fix systemd ordering cycle in nodeadm service files
+#   - Change WantedBy=multi-user.target → WantedBy=cloud-init.target
+#   - Remove cloud-final.service from After= directive
+# Applies to both nodeadm-run.service and nodeadm-boot-hook.service
+# ---------------------------------------------------------------------------
+
+NODEADM_SERVICES=(
+    "/etc/systemd/system/nodeadm-run.service"
+    "/etc/systemd/system/nodeadm-boot-hook.service"
+)
+
+DAEMON_RELOAD_NEEDED=false
+
+for SERVICE_FILE in "${NODEADM_SERVICES[@]}"; do
+    if [ ! -f "$SERVICE_FILE" ]; then
+        log "  ⚠ $SERVICE_FILE not found — skipping"
+        continue
+    fi
+
+    log "  Processing $SERVICE_FILE..."
+
+    # Fix 1: WantedBy=multi-user.target → WantedBy=cloud-init.target
+    if grep -q "WantedBy=multi-user.target" "$SERVICE_FILE"; then
+        log "  Found WantedBy=multi-user.target — applying fix..."
+        sudo sed -i \
+            's/WantedBy=multi-user.target/WantedBy=cloud-init.target/' \
+            "$SERVICE_FILE"
+        if grep -q "WantedBy=cloud-init.target" "$SERVICE_FILE"; then
+            log "  ✓ Fixed WantedBy in $SERVICE_FILE"
+            DAEMON_RELOAD_NEEDED=true
+        else
+            log "  ✗ ERROR: WantedBy sed substitution did not apply to $SERVICE_FILE"
+            exit 1
+        fi
+    else
+        log "  ✓ WantedBy already correct in $SERVICE_FILE — skipping"
+    fi
+
+    # Fix 2: Remove cloud-final.service from After= directive
+    # After=cloud-final.service creates a cycle when WantedBy=cloud-init.target:
+    #   cloud-init.target → nodeadm-run → After=cloud-final → cloud-init.target
+    # nodeadm-run only needs After=nodeadm-config.service which is safe to keep.
+    if grep -q "After=.*cloud-final\.service" "$SERVICE_FILE"; then
+        log "  Found cloud-final.service in After= directive — removing..."
+        sudo sed -i \
+            's/ cloud-final\.service//' \
+            "$SERVICE_FILE"
+        # Also handle case where cloud-final.service appears first in the list
+        sudo sed -i \
+            's/After=cloud-final\.service /After=/' \
+            "$SERVICE_FILE"
+        # Also handle case where cloud-final.service is the only After= value
+        sudo sed -i \
+            's/After=cloud-final\.service$/After=/' \
+            "$SERVICE_FILE"
+        if ! grep -q "cloud-final.service" "$SERVICE_FILE"; then
+            log "  ✓ Removed cloud-final.service from After= in $SERVICE_FILE"
+            DAEMON_RELOAD_NEEDED=true
+        else
+            log "  ✗ ERROR: cloud-final.service still present in $SERVICE_FILE"
+            exit 1
+        fi
+    else
+        log "  ✓ cloud-final.service not in After= in $SERVICE_FILE — skipping"
+    fi
+
+    # Show final Unit and Install sections for build log audit trail
+    log "  --- [Unit] section of $SERVICE_FILE ---"
+    grep -A5 "^\[Unit\]" "$SERVICE_FILE" || true
+    log "  --- [Install] section of $SERVICE_FILE ---"
+    grep -A2 "^\[Install\]" "$SERVICE_FILE" || true
+    log "  ---"
+done
+
+if [ "$DAEMON_RELOAD_NEEDED" = true ]; then
+    sudo systemctl daemon-reload
+    log "✓ systemctl daemon-reload complete"
+fi
+
+# ---------------------------------------------------------------------------
+# Issue 3: Create /usr/bin/networkctl shim for NetworkManager systems
+# nodeadm-internal calls "networkctl reload" after writing network config.
+# On RHEL9 with NetworkManager (not systemd-networkd), networkctl is absent.
+# ---------------------------------------------------------------------------
+
+NETWORKCTL="/usr/bin/networkctl"
+
+if [ -f "$NETWORKCTL" ]; then
+    log "✓ $NETWORKCTL already exists — skipping shim creation"
+else
+    log "Creating $NETWORKCTL shim (translates networkctl → nmcli)..."
+
+    sudo tee "$NETWORKCTL" > /dev/null << 'EOF'
+#!/usr/bin/env bash
+# networkctl shim — translates systemd-networkd calls to NetworkManager
+# Created by fix-nodeadm-cloudinit-ordering.sh during AMI build
+# Required because nodeadm-internal calls "networkctl reload" after writing
+# /run/systemd/network/ config files, but RHEL9 uses NetworkManager.
+case "$1" in
+    reload)
+        nmcli general reload
+        ;;
+    *)
+        # Silently ignore other networkctl subcommands
+        # nodeadm only uses "reload" so this is safe
+        exit 0
+        ;;
+esac
+EOF
+
+    sudo chmod +x "$NETWORKCTL"
+
+    if [ -x "$NETWORKCTL" ]; then
+        log "✓ $NETWORKCTL shim created and marked executable"
+    else
+        log "✗ ERROR: Failed to create $NETWORKCTL shim"
+        exit 1
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Issue 4: Mask nm-cloud-setup to prevent NetworkManager-cloud-setup RPM
+# from re-enabling it during package installs in the bootstrap script.
+# Masking (symlink → /dev/null) cannot be undone by any package operation.
+# ---------------------------------------------------------------------------
+
+log "Masking nm-cloud-setup (NetworkManager-cloud-setup RPM enables it on install)..."
+sudo systemctl mask nm-cloud-setup.timer
+sudo systemctl mask nm-cloud-setup.service
+
+NM_TIMER=$(systemctl is-enabled nm-cloud-setup.timer 2>/dev/null || true)
+NM_SERVICE=$(systemctl is-enabled nm-cloud-setup.service 2>/dev/null || true)
+log "nm-cloud-setup.timer:   ${NM_TIMER}"
+log "nm-cloud-setup.service: ${NM_SERVICE}"
+
+if [ "$NM_TIMER" = "masked" ] && [ "$NM_SERVICE" = "masked" ]; then
+    log "✓ nm-cloud-setup successfully masked"
+else
+    log "✗ ERROR: nm-cloud-setup masking did not apply correctly"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Final verification — confirm all fixes applied correctly
+# ---------------------------------------------------------------------------
+
+log "=== final verification ==="
+
+for SERVICE_FILE in "${NODEADM_SERVICES[@]}"; do
+    if [ ! -f "$SERVICE_FILE" ]; then
+        continue
+    fi
+    WANTED_BY=$(grep "WantedBy" "$SERVICE_FILE" || echo "NOT FOUND")
+    AFTER=$(grep "^After=" "$SERVICE_FILE" || echo "NOT FOUND")
+    log "  $SERVICE_FILE"
+    log "    After=:    $AFTER"
+    log "    WantedBy:  $WANTED_BY"
+    if echo "$WANTED_BY" | grep -q "cloud-init.target" && \
+       ! grep -q "cloud-final.service" "$SERVICE_FILE"; then
+        log "    ✓ ordering is correct — no cycle"
+    else
+        log "    ✗ WARNING: ordering may still cause a cycle"
+    fi
+done
+
+log "=== fix-nodeadm-cloudinit-ordering: complete ==="

--- a/templates/rhel/provisioners/install-worker.sh
+++ b/templates/rhel/provisioners/install-worker.sh
@@ -3,6 +3,7 @@
 set -o pipefail
 set -o nounset
 set -o errexit
+
 IFS=$'\n\t'
 export AWS_DEFAULT_OUTPUT="json"
 
@@ -53,8 +54,15 @@ fi
 ### Packages ###################################################################
 ################################################################################
 
+sudo yum install -y \
+  yum-utils \
+  yum-plugin-versionlock
+
 # Update the OS to begin with to catch up to the latest packages.
-sudo dnf update -y
+sudo dnf update -y --nobest
+
+# lock the version of the kernel and associated packages before we yum update
+sudo yum versionlock kernel-$(uname -r) kernel-headers-$(uname -r) kernel-devel-$(uname -r)
 
 # Install necessary packages
 sudo dnf install -y \
@@ -70,7 +78,16 @@ sudo dnf install -y \
   unzip \
   wget \
   mdadm \
-  pigz
+  pigz \
+  bind-utils \
+  iputils \
+  mtr \
+  nmap-ncat \
+  rh-amazon-rhui-client \
+  lsof \
+  tcpdump \
+  sos \
+  rsync
 
 export AWS_DEFAULT_REGION=$AWS_REGION
 export AWS_CA_BUNDLE="/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
@@ -215,7 +232,7 @@ sudo mkdir -p /var/lib/kubelet
 sudo mkdir -p /opt/cni/bin
 
 echo "Downloading binaries from: s3://$BINARY_BUCKET_NAME"
-AWS_DOMAIN=$(imds "/latest/meta-data/services/domain")
+AWS_DOMAIN=$(sudo imds "/latest/meta-data/services/domain")
 S3_DOMAIN="amazonaws.com"
 if [ "$BINARY_BUCKET_REGION" = "cn-north-1" ] || [ "$BINARY_BUCKET_REGION" = "cn-northwest-1" ]; then
   S3_DOMAIN="amazonaws.com.cn"
@@ -234,27 +251,41 @@ S3_PATH="s3://$BINARY_BUCKET_NAME/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin
 BINARIES=(
   kubelet
 )
+echo "Entering Script Changes to use wget rather than aws s3 cp to get EKS binaries."
 for binary in "${BINARIES[@]}"; do
   FILES=(
-    "$binary"
+    "$binary.gz"
+    "$binary.gz.sha256"
     "$binary.sha256"
   )
+  # Force wget when crossing partition boundaries (e.g., GovCloud <-> Commercial)
+  USE_WGET=false
+  if [[ "$AWS_REGION" == *"us-gov"* ]] && [[ "$BINARY_BUCKET_REGION" != *"us-gov"* ]]; then
+    echo "Cross-partition access detected (GovCloud -> Commercial). Using wget to fetch binaries from s3."
+    USE_WGET=true
+  fi
   for file in "${FILES[@]}"; do
-    if ! aws s3 cp --region $BINARY_BUCKET_REGION "$S3_PATH/$file" .; then
-      echo "Fetching ${file} from s3 failed, trying again with unauthenticated request."
-      aws s3 cp --no-sign-request --region $BINARY_BUCKET_REGION "$S3_PATH/$file" .
+    if [ "$AWS_CREDS_OK" = "true" ] && [ "$USE_WGET" = "false" ]; then
+      echo "AWS credentials present - using them to copy binaries from s3."
+      sudo aws s3 cp --region $BINARY_BUCKET_REGION "$S3_PATH/$file" .
+    else
+      echo "Fetching ${file} from s3 using wget"
+      sudo wget "$S3_URL_BASE/$file"
     fi
   done
 
+  sudo sha256sum -c $binary.gz.sha256
+  sudo gunzip $binary.gz
   sudo sha256sum -c $binary.sha256
   sudo chmod +x $binary
   sudo chown root:root $binary
-  sudo mv --context $binary /usr/bin/
+  sudo mv $binary /usr/bin/
+  sudo restorecon -vF /usr/bin/$binary
 done
 
 sudo rm ./*.sha256
 
-kubelet --version > "${WORKING_DIR}/kubelet-version.txt"
+sudo kubelet --version > "${WORKING_DIR}/kubelet-version.txt"
 sudo mv "${WORKING_DIR}/kubelet-version.txt" /etc/eks/kubelet-version.txt
 
 sudo systemctl enable ebs-initialize-bin@kubelet
@@ -264,12 +295,24 @@ sudo systemctl enable ebs-initialize-bin@kubelet
 ################################################################################
 
 ECR_CREDENTIAL_PROVIDER_BINARY="ecr-credential-provider"
+FILES=(
+  "$ECR_CREDENTIAL_PROVIDER_BINARY.sha256"
+  "$ECR_CREDENTIAL_PROVIDER_BINARY.gz"
+  "$ECR_CREDENTIAL_PROVIDER_BINARY.gz.sha256"   
+)
+for file in "${FILES[@]}"; do
+  if [ "$AWS_CREDS_OK" = "true" ] && [ "$USE_WGET" = "false" ]; then
+    echo "AWS credentials present - using them to copy ${ECR_CREDENTIAL_PROVIDER_BINARY} from s3."
+    sudo aws s3 cp --region $BINARY_BUCKET_REGION "$S3_PATH/$file" .
+  else
+    echo "Fetching ${file} from s3 using wget"
+    sudo wget "$S3_URL_BASE/$file"
+  fi
+done
 
-if ! aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$ECR_CREDENTIAL_PROVIDER_BINARY .; then
-  echo "Fetching ${ECR_CREDENTIAL_PROVIDER_BINARY} from s3 failed, trying again with unauthenticated request."
-  aws s3 cp --no-sign-request --region $BINARY_BUCKET_REGION $S3_PATH/$ECR_CREDENTIAL_PROVIDER_BINARY .
-fi
-
+sudo sha256sum -c "$ECR_CREDENTIAL_PROVIDER_BINARY.gz.sha256"
+sudo gunzip "$ECR_CREDENTIAL_PROVIDER_BINARY.gz"
+sudo sha256sum -c "$ECR_CREDENTIAL_PROVIDER_BINARY.sha256"
 sudo chmod +x $ECR_CREDENTIAL_PROVIDER_BINARY
 sudo mkdir -p /etc/eks/image-credential-provider
 sudo mv $ECR_CREDENTIAL_PROVIDER_BINARY /etc/eks/image-credential-provider/
@@ -363,7 +406,7 @@ fi
 ### AMI Metadata ###############################################################
 ################################################################################
 
-BASE_AMI_ID=$($WORKING_DIR/shared/bin/imds /latest/meta-data/ami-id)
+BASE_AMI_ID=$(sudo $WORKING_DIR/shared/bin/imds /latest/meta-data/ami-id)
 cat << EOF | sudo tee /etc/eks/release
 BASE_AMI_ID="$BASE_AMI_ID"
 BUILD_TIME="$(date)"

--- a/templates/rhel/provisioners/user-data-init.sh
+++ b/templates/rhel/provisioners/user-data-init.sh
@@ -1,0 +1,223 @@
+#!/bin/bash
+# File: user-data-init.sh
+# Ensures SSH and SSM agent are ready before Packer connects
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Logging function
+# ---------------------------------------------------------------------------
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+    logger -t user-data "$*"
+}
+
+# ---------------------------------------------------------------------------
+# Helper to capture a clean single-line status string, stripping all
+# whitespace/carriage-returns regardless of which branch of || ran.
+# ---------------------------------------------------------------------------
+get_status() {
+    local raw
+    raw=$(systemctl is-active "$1" 2>/dev/null || echo "unknown")
+    echo "$raw" | tr -d '[:space:]'
+}
+
+log "=== User Data Initialization Started ==="
+
+# ---------------------------------------------------------------------------
+# IMDSv2 token
+# ---------------------------------------------------------------------------
+TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" \
+        -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" \
+        -s --max-time 5 || echo "")
+if [ -z "$TOKEN" ]; then
+    log "WARNING: Failed to get IMDSv2 token — continuing without metadata"
+fi
+
+# ---------------------------------------------------------------------------
+# Region detection
+# ---------------------------------------------------------------------------
+REGION=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" \
+    -s --max-time 5 \
+    http://169.254.169.254/latest/meta-data/placement/region 2>/dev/null \
+    || echo "us-gov-west-1")
+REGION=$(echo "$REGION" | tr -d '[:space:]')
+log "Detected region: $REGION"
+
+# ---------------------------------------------------------------------------
+# Ensure REGION DNF variable is set — required for RHUI repo resolution.
+# This is normally created by rh-amazon-rhui-client on first boot but can
+# be missing if cloud-init initialization order causes a race condition.
+# ---------------------------------------------------------------------------
+# if [ ! -f /etc/dnf/vars/REGION ]; then
+#     log "WARNING: /etc/dnf/vars/REGION missing — creating from IMDSv2 region detection..."
+#     mkdir -p /etc/dnf/vars
+#     echo "$REGION" | tee /etc/dnf/vars/REGION >/dev/null
+#     log "✓ Set /etc/dnf/vars/REGION to $REGION"
+# else
+#     log "✓ /etc/dnf/vars/REGION already set to: $(cat /etc/dnf/vars/REGION)"
+# fi
+
+# ---------------------------------------------------------------------------
+# Trellix / McAfee — stop, disable, and mask
+# ---------------------------------------------------------------------------
+log "Temporarily disabling Trellix/McAfee..."
+sudo systemctl stop    mfeespd mfetpd || true
+sudo systemctl disable mfeespd mfetpd || true
+sudo systemctl mask    mfeespd mfetpd || true
+log "✓ Trellix/McAfee stopped, disabled, and masked"
+
+# ---------------------------------------------------------------------------
+# Misc terminal / shell settings
+# ---------------------------------------------------------------------------
+log "Disabling enable-bracketed-paste ..."
+echo "set enable-bracketed-paste off" >> /etc/inputrc
+
+# ---------------------------------------------------------------------------
+# SELinux — disable early so subsequent steps are not blocked
+# ---------------------------------------------------------------------------
+log "Disabling SELinux..."
+setenforce 0 || log "Warning: Could not set SELinux to permissive (may already be disabled)"
+grubby --update-kernel ALL --args selinux=0
+sed -i 's/^SELINUX=.*/SELINUX=disabled/' /etc/selinux/config
+log "✓ SELinux disabled"
+
+# ---------------------------------------------------------------------------
+# Packer working directories
+# ---------------------------------------------------------------------------
+log "Creating Packer working directories..."
+mkdir -p /opt/packer/worker
+chmod -R 755 /opt/packer
+chown -R ec2-user:ec2-user /opt/packer
+restorecon -R /opt/packer 2>/dev/null || true
+log "✓ Created /opt/packer directory"
+
+# ---------------------------------------------------------------------------
+# Restore ec2-user SSH authorized_keys from IMDSv2 if the file is missing
+# ---------------------------------------------------------------------------
+AUTH_KEYS="/home/ec2-user/.ssh/authorized_keys"
+if [ ! -f "$AUTH_KEYS" ]; then
+    PUBLIC_KEY=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" \
+        -s --max-time 5 \
+        http://169.254.169.254/latest/meta-data/public-keys/0/openssh-key \
+        || echo "")
+    if [ -n "$PUBLIC_KEY" ]; then
+        mkdir -p /home/ec2-user/.ssh
+        echo "$PUBLIC_KEY" > "$AUTH_KEYS"
+        chmod 700 /home/ec2-user/.ssh
+        chmod 600 "$AUTH_KEYS"
+        chown -R ec2-user:ec2-user /home/ec2-user/.ssh
+        restorecon -R /home/ec2-user/.ssh 2>/dev/null || true
+        log "Restored authorized_keys from IMDS"
+    else
+        log "No public key found in IMDS"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# OS version info
+# ---------------------------------------------------------------------------
+RHEL_VERSION=$(rpm -E %{rhel})
+log "Detected RHEL version: $RHEL_VERSION"
+cat /etc/os-release
+
+# ---------------------------------------------------------------------------
+# AWS CLI — Add to /etc/profile.d/ so it's available for all users including root
+# ---------------------------------------------------------------------------
+cat > /etc/profile.d/aws-cli.sh << 'EOF'
+# AWS CLI PATH configuration
+export PATH="/usr/local/aws-cli/v2/current/bin:$PATH"
+EOF
+chmod +x /etc/profile.d/aws-cli.sh
+
+# ---------------------------------------------------------------------------
+# SSM agent — install / start only if not already active
+# ---------------------------------------------------------------------------
+
+# FIX: capture status into a variable first, then strip whitespace separately
+# so that tr -d applies to the full output and not just the echo fallback.
+SSM_STATUS=$(get_status amazon-ssm-agent)
+log "SSM agent status: $SSM_STATUS"
+
+if rpm -q amazon-ssm-agent >/dev/null 2>&1 && [ "$SSM_STATUS" = "active" ]; then
+    SSM_VERSION=$(rpm -q amazon-ssm-agent --qf '%{VERSION}' 2>/dev/null || echo "unknown")
+    SSM_VERSION=$(echo "$SSM_VERSION" | tr -d '[:space:]')
+    log "✓ SSM agent already installed and running (version: $SSM_VERSION) — skipping setup"
+else
+    log "SSM agent not installed or not running (status: $SSM_STATUS) — proceeding with setup..."
+
+    # Determine the correct download URL for this region
+    case "$REGION" in
+        us-gov-west-1)
+            SSM_URL="https://s3.us-gov-west-1.amazonaws.com/amazon-ssm-us-gov-west-1/latest/linux_amd64/amazon-ssm-agent.rpm"
+            log "Using GovCloud West SSM agent URL"
+            ;;
+        us-gov-east-1)
+            SSM_URL="https://s3.us-gov-east-1.amazonaws.com/amazon-ssm-us-gov-east-1/latest/linux_amd64/amazon-ssm-agent.rpm"
+            log "Using GovCloud East SSM agent URL"
+            ;;
+        *)
+            SSM_URL="https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm"
+            log "Using Commercial SSM agent URL"
+            ;;
+    esac
+
+    # Download SSM agent
+    cd /tmp
+    if curl -f -s --max-time 60 -o amazon-ssm-agent.rpm "$SSM_URL"; then
+        log "✓ Downloaded SSM agent"
+        ls -al ./amazon-ssm-agent.rpm
+
+        # Install or update
+        if rpm -q amazon-ssm-agent >/dev/null 2>&1; then
+            log "Updating existing SSM agent..."
+            dnf update -y --disablerepo='*' ./amazon-ssm-agent.rpm 2>&1 | tee /tmp/dnf-ssm-update.log || log "Update had warnings (continuing)"
+        else
+            log "Installing SSM agent..."
+            dnf install -y --disablerepo='*' ./amazon-ssm-agent.rpm 2>&1 | tee /tmp/dnf-ssm-install.log || log "Install had warnings (continuing)"
+        fi
+
+        rm -f amazon-ssm-agent.rpm
+        log "✓ SSM agent package installed"
+    else
+        log "✗ WARNING: Failed to download SSM agent from $SSM_URL"
+        log "Continuing without SSM agent..."
+    fi
+
+    # Enable and start SSM agent only if the binary landed on disk
+    if [ -f /usr/bin/amazon-ssm-agent ]; then
+        log "Starting SSM agent..."
+        systemctl enable  amazon-ssm-agent 2>/dev/null || log "Could not enable SSM agent"
+        systemctl start amazon-ssm-agent 2>/dev/null || log "Could not start SSM agent"
+
+        # Give SSM a moment to initialise
+        sleep 3
+
+        # Re-check status after start attempt
+        SSM_STATUS=$(get_status amazon-ssm-agent)
+        if [ "$SSM_STATUS" = "active" ]; then
+            SSM_VERSION=$(rpm -q amazon-ssm-agent --qf '%{VERSION}' 2>/dev/null || echo "unknown")
+            SSM_VERSION=$(echo "$SSM_VERSION" | tr -d '[:space:]')
+            log "✓ SSM agent is running (version: $SSM_VERSION)"
+        else
+            log "✗ WARNING: SSM agent installed but failed to start (status: $SSM_STATUS)"
+        fi
+    else
+        log "✗ WARNING: SSM agent binary not found after install attempt"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Final status check
+# ---------------------------------------------------------------------------
+log "=== Final Status Check ==="
+SSH_STATUS=$(get_status sshd)
+SSM_STATUS=$(get_status amazon-ssm-agent)
+log "SSH: $SSH_STATUS"
+log "SSM: $SSM_STATUS"
+
+log "SSH and SSM ready - Packer can connect now"
+
+# Signal completion
+touch /tmp/user-data-complete
+log "=== User Data Initialization Complete ==="

--- a/templates/rhel/template.json
+++ b/templates/rhel/template.json
@@ -116,7 +116,9 @@
         "container_selinux_version": "{{ user `container_selinux_version`}}",
         "containerd_version": "{{ user `containerd_version`}}",
         "kubernetes": "{{ user `kubernetes_version`}}/{{ user `kubernetes_build_date` }}/bin/linux/{{ user `arch` }}",
-        "ssm_agent_version": "{{ user `ssm_agent_version`}}"
+        "ssm_agent_version": "{{ user `ssm_agent_version`}}",
+        "amazon_eks_ami_rhel_repo": "https://github.com/aws-samples/amazon-eks-ami-rhel.git",
+        "amazon_eks_ami_rhel_repo_commit_hash": "7df18f0ecc550bcba7adfd53410acbfb0423e22e"
       },
       "ami_name": "{{user `ami_name`}}",
       "ami_description": "{{ user `ami_description` }}, {{ user `ami_component_description` }}",
@@ -203,7 +205,7 @@
       "script": "{{template_dir}}/provisioners/install-worker.sh",
       "environment_vars": [
         "AWS_ACCESS_KEY_ID={{user `aws_access_key_id`}}",
-	"AWS_CLI_URL={{user `aws_cli_url`}}",
+        "AWS_CLI_URL={{user `aws_cli_url`}}",
         "AWS_REGION={{user `aws_region`}}",
         "AWS_SECRET_ACCESS_KEY={{user `aws_secret_access_key`}}",
         "AWS_SESSION_TOKEN={{user `aws_session_token`}}",
@@ -294,6 +296,11 @@
       "type": "shell",
       "remote_folder": "{{ user `remote_folder`}}",
       "script": "{{template_dir}}/provisioners/configure-selinux.sh"
+    },
+    {
+      "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
+      "script": "{{template_dir}}/provisioners/fix-nodeadm-cloudinit-ordering.sh"
     }
   ],
   "post-processors": [

--- a/templates/shared/provisioners/generate-version-info.sh
+++ b/templates/shared/provisioners/generate-version-info.sh
@@ -16,7 +16,7 @@ sudo rpm --query --all --queryformat '\{"%{NAME}": "%{VERSION}-%{RELEASE}"\}\n' 
 
 # kernel modules
 for modname in $(sudo lsmod | cut -d' ' -f 1 | tail -n +2); do
-  MOD_VERSION=$(sudo modinfo ${modname} --field version)
+  MOD_VERSION=$(sudo modinfo ${modname} --field version 2>/dev/null || true)
   if [ -n "$MOD_VERSION" ]; then
     echo "$(jq ".kernel_modules.${modname} = \"$MOD_VERSION\"" $OUTPUT_FILE)" > $OUTPUT_FILE
   fi


### PR DESCRIPTION
I am not requesting a merge at this time. I am opening this PR to share the changes I have made locally and invite feedback from maintainers and the community. If anyone sees potential issues, unintended side effects, or knows of a better approach to solving these problems, I would greatly appreciate hearing it before I finalize these changes for our production environment.

**This PR fixes this issue:** 
RHEL9 EKS nodes fail to join cluster with cloud-init 24.4+ due to systemd ordering cycle, missing networkctl shim, and nm-cloud-setup re-enablement

**Problem:**
When building a custom EKS AMI on RHEL 9 using this repository and deploying to AWS GovCloud (us-gov-west-1), EKS worker nodes consistently fail to join the cluster automatically at boot. The nodes come up healthy but kubelet never starts, requiring manual SSH access and running nodeadm init directly to recover each node individually — which is not viable at scale.

Investigation revealed three separate but related root causes, all of which must be fixed together for nodes to join reliably:

---
### **Root Cause 1** — systemd ordering cycle: WantedBy=multi-user.target + After=cloud-final.service
cloud-init 24.4 (shipped in RHEL 9.7 as cloud-init-24.4-7.el9_7.1) changed the systemd ordering of its final stage so that cloud-final.service now runs after multi-user.target instead of before it.
Both nodeadm-run.service and nodeadm-boot-hook.service as installed by this repository declare:
```
After=nodeadm-config.service cloud-final.service
WantedBy=multi-user.target
```
This creates a circular dependency at boot:
```
multi-user.target
  → wants nodeadm-run.service
    → After=cloud-final.service
      → cloud-final.service now runs After=multi-user.target
        → CYCLE
```
systemd detects the cycle and **silently deletes the nodeadm-run start job**, so nodeadm never executes, kubelet never starts, and the node never joins the cluster. The failure appears in the journal as:
```
systemd[1]: multi-user.target: Found ordering cycle on nodeadm-run.service/start;
            has dependency on cloud-final.service/start, multi-user.target/start
systemd[1]: multi-user.target: Job nodeadm-run.service/start deleted to break
            ordering cycle starting with multi-user.target/start
```
Fix:

1. Change WantedBy=multi-user.target → WantedBy=cloud-init.target in both service files
2. Remove cloud-final.service from the After= directive entirely — nodeadm-run only needs to run after nodeadm-config.service, which is a safe sequential dependency with no cycle

After the fix:
```
iniAfter=nodeadm-config.service
WantedBy=cloud-init.target
```
---
### **Root Cause 2** — Missing `/usr/bin/networkctl` on RHEL9 with NetworkManager

`nodeadm-internal` writes systemd-networkd configuration files to `/run/systemd/network/` and then calls `networkctl reload` via the `ExecStartPost` directive of `udev-net-manager@eth0.service`. On RHEL9 the default network manager is **NetworkManager**, not `systemd-networkd`, so `networkctl` is not installed. This causes `udev-net-manager@eth0.service` to fail and retry continuously:
```
systemd: udev-net-manager@eth0.service: Failed to locate executable /usr/bin/networkctl:
         No such file or directory
systemd: Failed to start Setup network interface eth0.
```

**Fix:** Create a `/usr/bin/networkctl` shim during the AMI Packer build that translates `networkctl reload` to the NetworkManager equivalent `nmcli general reload`, and silently ignores all other subcommands that nodeadm does not use.

---
### **Root Cause 3** — `nm-cloud-setup` re-enabled by `NetworkManager-cloud-setup` RPM post-install scriptlet

The existing documentation and prior work in this repository correctly identifies that `nm-cloud-setup` causes network routing disruption on RHEL9 EKS nodes and must be disabled. However, simply running `systemctl disable` during the AMI build is insufficient because the `NetworkManager-cloud-setup` RPM post-install scriptlet **re-enables** `nm-cloud-setup.timer` and `nm-cloud-setup.service` whenever the package is installed or upgraded — which occurs during bootstrap user-data execution via `yum install`.

A plain `disable` creates no override file in `/etc/systemd/system/`, so the RPM scriptlet can restore the symlinks freely. The result is that `nm-cloud-setup` ends up `enabled` at runtime even though it was disabled during the AMI build, requiring an unconditional reboot in bootstrap scripts to apply the disable — which in turn sends `SIGTERM` to cloud-init mid-execution, causing `modules-final` to be marked `FAILED` in `/var/lib/cloud/data/status.json`, preventing bootstrap from being recognized as having completed on subsequent reboots.

**Fix:** Use `systemctl mask` instead of `systemctl disable`. Masking creates symlinks to `/dev/null` in `/etc/systemd/system/` which take precedence over the RPM-owned unit files in `/usr/lib/systemd/system/` and **cannot be overwritten or re-enabled by any package operation**.

---
### Fix Implementation

This PR adds a new Packer provisioner script:

**`templates/rhel/provisioners/fix-nodeadm-cloudinit-ordering.sh`**

This script runs as the **last provisioner step** in the Packer build, after `install-nodeadm.sh`, and applies all three fixes atomically:

1. Patches `WantedBy=multi-user.target` → `WantedBy=cloud-init.target` in both `nodeadm-run.service` and `nodeadm-boot-hook.service`
2. Removes `cloud-final.service` from the `After=` directive in both service files
3. Creates `/usr/bin/networkctl` shim (translates `networkctl reload` → `nmcli general reload`)
4. Masks `nm-cloud-setup.timer` and `nm-cloud-setup.service` via symlinks to `/dev/null`
5. Runs a final verification block that prints the resulting `After=` and `WantedBy=` values for each service file to the Packer build log as an audit trail

The script is fully idempotent — it skips steps that are already correct and exits with an error if any fix fails to apply, causing the Packer build to fail fast rather than producing a broken AMI.

---

### Verified Fix — Boot sequence on patched AMI

With the fix applied, the node boot sequence is:
```
[13s]  nodeadm-config.service → completes, writes kubelet config, ca.crt, kubeconfig
[13s]  nodeadm-run.service    → no cycle, fires immediately after nodeadm-config
         nodeadm: done! {"duration": 0.266s}
         Finished EKS Nodeadm Run
[13s]  kubelet starts automatically
[15s]  Successfully registered node ip-10-70-88-149.us-gov-west-1.compute.internal
[20s]  bootstrap user-data runs (diagnostic only at this point — node already joined)
       cloud-init finishes cleanly with no SIGTERM, no reboot
```
The node joins the cluster automatically within 15 seconds of boot with no manual intervention.

Related Issues and PRs

- aws-samples/amazon-eks-ami-rhel#20 — Prior PR addressing the WantedBy=multi-user.target issue. This PR extends that fix by also removing After=cloud-final.service, which was identified as a second independent ordering cycle that persists even after the WantedBy fix is applied.
- aws-samples/amazon-eks-ami-rhel#2 — Documents the nm-cloud-setup network routing issue on RHEL9 and recommends disabling and rebooting. This PR supersedes that approach by using systemctl mask to make the disable permanent across package installs.
- awslabs/amazon-eks-ami#1917 — nodeadm-run.service fails when containerd is not fully initialized; discusses the After= directive in the nodeadm-run unit file and the ordering implications.
- awslabs/amazon-eks-ami#2127 — Worker nodes fail to auto-join cluster, requiring nodeadm init to be run manually — the same symptom this PR fixes for RHEL9.
- awslabs/amazon-eks-ami#2360 — nodeadm-config.service ordering issues with cloud-init and network initialization on AL2023, related class of systemd ordering problems.
- cloud-init upstream breaking changes — https://cloudinit.readthedocs.io/en/latest/reference/breaking_changes.html#id4 — documents the cloud-init 24.4 change that moves cloud-final to run after multi-user.target, which is the root trigger for this entire issue class on RHEL9.
- Red Hat KB article — https://access.redhat.com/solutions/6319811 — documents the nm-cloud-setup network routing issue on RHEL EC2 instances.

**Testing**
Tested on:

RHEL 9.7 (cloud-init-24.4-7.el9_7.1)
AWS GovCloud (us-gov-west-1)
EKS 1.34
Packer with templates/rhel/template.json
Node instance type: m5a.4xlarge

Before this fix: 0% of nodes joined the cluster automatically. Every node required manual nodeadm init via SSM Session Manager.
After this fix: 100% of nodes join the cluster automatically within 15 seconds of boot across multiple node groups and instance launches.